### PR TITLE
feat: use ratatui instead of tui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ unit-human = ["human_format"]
 unit-duration = ["compound_duration"]
 render-tui-termion = ["crosstermion/tui-react-termion"]
 render-tui-crossterm = ["crosstermion/tui-react-crossterm", "crosstermion/input-async-crossterm"]
-render-tui = ["tui",
+render-tui = ["ratatui",
     "unicode-segmentation",
     "unicode-width",
     "crosstermion/input-async",
@@ -72,7 +72,7 @@ parking_lot = { version = "0.12.1", optional = true, default-features = false }
 log = { version = "0.4.8", optional = true }
 
 # render-tui
-tui = { version = "0.19.0", optional = true, default-features = false }
+ratatui = { version = "0.20.1", optional = true, default-features = false }
 tui-react = { version = "0.19.0", optional = true }
 futures-core = { version = "0.3.4", optional = true, default-features = false }
 futures-lite = { version = "1.5.0", optional = true }
@@ -115,3 +115,8 @@ async-io = "1.1.0"
 name = "usage"
 path = "benches/usage.rs"
 harness = false
+
+[patch.crates-io]
+# Remove this once the ratatui is merged into https://github.com/Byron/tui-crates
+crosstermion = { git = "https://github.com/joshka/tui-crates", branch = "ratatui" }
+tui-react = { git = "https://github.com/joshka/tui-crates", branch = "ratatui" }

--- a/src/render/tui/draw/all.rs
+++ b/src/render/tui/draw/all.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Modifier, Style},

--- a/src/render/tui/draw/information.rs
+++ b/src/render/tui/draw/information.rs
@@ -1,4 +1,4 @@
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Modifier, Style},

--- a/src/render/tui/draw/messages.rs
+++ b/src/render/tui/draw/messages.rs
@@ -1,6 +1,6 @@
 use std::time::SystemTime;
 
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Modifier, Style},

--- a/src/render/tui/draw/progress.rs
+++ b/src/render/tui/draw/progress.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use humantime::format_duration;
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -349,20 +349,20 @@ fn draw_progress_bar_fn(
         for x in fractional_progress_rect.left()..fractional_progress_rect.right() {
             let cell = buf.get_mut(x, y);
             cell.set_fg(color);
-            cell.set_symbol(tui::symbols::block::FULL);
+            cell.set_symbol(ratatui::symbols::block::FULL);
         }
     }
     if fractional_progress_rect.width < bound.width {
         static BLOCK_SECTIONS: [&str; 9] = [
             " ",
-            tui::symbols::block::ONE_EIGHTH,
-            tui::symbols::block::ONE_QUARTER,
-            tui::symbols::block::THREE_EIGHTHS,
-            tui::symbols::block::HALF,
-            tui::symbols::block::FIVE_EIGHTHS,
-            tui::symbols::block::THREE_QUARTERS,
-            tui::symbols::block::SEVEN_EIGHTHS,
-            tui::symbols::block::FULL,
+            ratatui::symbols::block::ONE_EIGHTH,
+            ratatui::symbols::block::ONE_QUARTER,
+            ratatui::symbols::block::THREE_EIGHTHS,
+            ratatui::symbols::block::HALF,
+            ratatui::symbols::block::FIVE_EIGHTHS,
+            ratatui::symbols::block::THREE_QUARTERS,
+            ratatui::symbols::block::SEVEN_EIGHTHS,
+            ratatui::symbols::block::FULL,
         ];
         // Get the index based on how filled the remaining part is
         let index = ((((bound.width as f32 * fraction) - fractional_progress_rect.width as f32) * 8f32).round()

--- a/src/render/tui/engine.rs
+++ b/src/render/tui/engine.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use futures_lite::StreamExt;
-use tui::layout::Rect;
+use ratatui::layout::Rect;
 
 use crate::{
     render::tui::{draw, ticker},

--- a/src/render/tui/mod.rs
+++ b/src/render/tui/mod.rs
@@ -55,5 +55,5 @@ mod utils;
 
 pub use engine::*;
 /// Useful for bringing up the TUI without bringing in the `tui` crate yourself
-pub use tui as tui_export;
+pub use ratatui as tui_export;
 pub use utils::ticker;


### PR DESCRIPTION
- note: the Cargo.toml change should be removed once the ratatui patch is applied to crosstermion and tui-react

I ran make tests

Relies on https://github.com/Byron/tui-crates/pull/2

[![asciicast](https://asciinema.org/a/gkbGZ3SW5yRv7NjDZVp1q5cEM.svg)](https://asciinema.org/a/gkbGZ3SW5yRv7NjDZVp1q5cEM)