### PR TITLE
refactor: use humantime and humansize for humanly units

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ progress-tree-hp-hashmap = ["dashmap"]
 progress-tree-log = ["log"]
 progress-log = ["log"]
 unit-bytes = ["bytesize"]
-unit-human = ["human_format"]
-unit-duration = ["compound_duration"]
+unit-human = ["humansize"]
+unit-duration = ["humantime"]
 render-tui-termion = ["crosstermion/tui-react-termion"]
 render-tui-crossterm = ["crosstermion/tui-react-crossterm", "crosstermion/input-async-crossterm"]
 render-tui = ["tui",
@@ -76,7 +76,7 @@ tui = { package = "ratatui", version = "0.20.1", optional = true, default-featur
 tui-react = { version = "0.20.0", optional = true }
 futures-core = { version = "0.3.4", optional = true, default-features = false }
 futures-lite = { version = "1.5.0", optional = true }
-humantime = { version = "2.0.0", optional = true }
+humantime = { version = "2.1.0", optional = true }
 unicode-segmentation = { version = "1.6.0", optional = true }
 unicode-width = { version = "0.1.7", optional = true }
 crosstermion = { version = "0.11.0", optional = true, default-features = false }
@@ -92,8 +92,8 @@ is-terminal = { version = "0.4.9", optional = true }
 
 # units
 bytesize = { version = "1.0.1", optional = true }
-human_format = { version = "1.0.3", optional = true }
-compound_duration = { version = "1.2.0", optional = true }
+humansize = { version = "2.1.3", optional = true }
+# humantime is in the render-tui section
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ This crate comes with various cargo features to tailor it to your needs.
 * **unit-bytes**
   * Supports dynamic byte display using the tiny `bytesize` crate.
 * **unit-human**
-  * Display counts in a way that is easier to grasp for humans, using the tiny `human_format` crate.
+  * Display counts in a way that is easier to grasp for humans, using the tiny `humansize` crate.
 * **unit-duration**
-  * Displays time in seconds like '_5m4s_' using the tiny `compound_duration` crate.
+  * Displays time in seconds like '_5m4s_' using the tiny `humantime` crate.
 
 ## Features
 

--- a/examples/units.rs
+++ b/examples/units.rs
@@ -59,10 +59,8 @@ fn work_for_a_long_time_blocking(root: Arc<Tree>) {
         )),
     );
 
-    fn formatter(decimals: usize) -> unit::human::Formatter {
-        let mut f = unit::human::Formatter::new();
-        f.with_decimals(decimals);
-        f
+    fn formatter(decimals: usize) -> humansize::FormatSizeOptions {
+        humansize::DECIMAL.decimal_places(decimals).decimal_zeroes(decimals)
     }
     let human_count = root.add_child_with_id("item count unknown", *b"ITUK");
     human_count.init(

--- a/src/unit/duration.rs
+++ b/src/unit/duration.rs
@@ -1,4 +1,6 @@
-use std::fmt;
+use std::{fmt, time::Duration as StdDuration};
+
+use humantime::format_duration;
 
 use crate::{progress::Step, unit::DisplayValue};
 
@@ -8,13 +10,13 @@ pub struct Duration;
 
 impl DisplayValue for Duration {
     fn display_current_value(&self, w: &mut dyn fmt::Write, value: Step, _upper: Option<Step>) -> fmt::Result {
-        w.write_str(&compound_duration::format_dhms(value))
+        w.write_str(&format_duration(StdDuration::new(value as u64, 0)).to_string())
     }
     fn separator(&self, w: &mut dyn fmt::Write, _value: Step, _upper: Option<Step>) -> fmt::Result {
         w.write_str(" of ")
     }
     fn display_upper_bound(&self, w: &mut dyn fmt::Write, upper_bound: Step, _value: Step) -> fmt::Result {
-        w.write_str(&compound_duration::format_dhms(upper_bound))
+        w.write_str(&format_duration(StdDuration::new(upper_bound as u64, 0)).to_string())
     }
 
     fn dyn_hash(&self, state: &mut dyn std::hash::Hasher) {

--- a/src/unit/human.rs
+++ b/src/unit/human.rs
@@ -1,25 +1,29 @@
-use std::{fmt, fmt::Debug, hash::Hasher};
+use std::{fmt, hash::Hasher};
 
-pub use human_format::{Formatter, Scales};
+pub use humansize::{format_size_i, FormatSizeOptions, ISizeFormatter};
+#[cfg(doc)]
+use humansize::{BINARY, DECIMAL};
 
 use crate::{progress::Step, unit::DisplayValue};
 
-/// A helper for formatting numbers in a format easily read by humans in renderers, as in `2.54 million objects`
-#[derive(Debug)]
+/// A helper for formatting numbers in a format easily read by humans in
+/// renderers, as in `2.54 million objects`
 pub struct Human {
     /// The name of the represented unit, like 'items' or 'objects'.
     pub name: &'static str,
-    /// The formatter to format the actual numbers.
-    pub formatter: Formatter,
+    /// Formatting options of [`humansize`].
+    pub format_options: FormatSizeOptions,
 }
 
 impl Human {
-    /// A convenience method to create a new new instance and its `formatter` and `name` fields.
-    pub fn new(formatter: Formatter, name: &'static str) -> Self {
-        Human { name, formatter }
+    /// A convenience method to create a new instance with a set of
+    /// [`humansize`] format options, like [`BINARY`] or [`DECIMAL`],
+    /// and a name for the unit.
+    pub fn new(format_options: FormatSizeOptions, name: &'static str) -> Self {
+        Self { name, format_options }
     }
     fn format_bytes(&self, w: &mut dyn fmt::Write, value: Step) -> fmt::Result {
-        let string = self.formatter.format(value as f64);
+        let string = format_size_i(value as f64, self.format_options);
         for token in string.split(' ') {
             w.write_str(token)?;
         }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -13,26 +13,19 @@ mod dynamic {
     }
     #[cfg(feature = "unit-human")]
     mod human {
-        use prodash::unit::{self, display, human, Human};
+        use prodash::unit::{self, display, Human};
 
         #[test]
         fn various_combinations() {
             let unit = unit::dynamic_and_mode(
-                Human::new(
-                    {
-                        let mut f = human::Formatter::new();
-                        f.with_decimals(1);
-                        f
-                    },
-                    "objects",
-                ),
+                Human::new(humansize::DECIMAL.decimal_places(1).decimal_zeroes(1), "objects"),
                 display::Mode::with_percentage(),
             );
             assert_eq!(
                 format!("{}", unit.display(100_002, Some(7_500_000), None)),
-                "100.0k/7.5M objects [1%]"
+                "100.0kB/7.5MB objects [1%]"
             );
-            assert_eq!(format!("{}", unit.display(100_002, None, None)), "100.0k objects");
+            assert_eq!(format!("{}", unit.display(100_002, None, None)), "100.0kB objects");
         }
     }
     mod range {


### PR DESCRIPTION
Currently compound_duration and human_format are used. They don't see much use like the replacements, and the former has a [32-bit problem](https://github.com/nbari/compound_duration/pull/2).

Another reason is that I, as a member of the Debian Rust team, hope to introduce less Rust crates into Debian, especially the less used ones. Packaging is more or less a manual process, unlike cargo publish which is automagic.