### PR TITLE
switch from `humantime` to `jiff`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ unicode-width = { version = "0.1.7", optional = true }
 crosstermion = { version = "0.14.0", optional = true, default-features = false }
 async-io = { version = "2.2.1", optional = true }
 
-# localtime support for render-tui
-jiff = { version = "0.1.1", optional = true }
+# localtime support for render-tui and duration formatting
+jiff = { version = "0.2.4", optional = true }
 
 # line renderer
 ctrlc = { version = "3.1.4", optional = true, default-features = false, features = ['termination'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ include = ["src/**/*", "README.md", "LICENSE.md", "CHANGELOG.md"]
 license = "MIT"
 repository = "https://github.com/Byron/prodash"
 readme = "README.md"
+rust-version = "1.74"
 
 [lib]
 doctest = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ progress-tree-log = ["log"]
 progress-log = ["log"]
 unit-bytes = ["bytesize"]
 unit-human = ["human_format"]
-unit-duration = ["humantime"]
+unit-duration = ["jiff"]
 render-tui-crossterm = ["crosstermion/tui-react-crossterm", "crosstermion/input-async-crossterm"]
 render-tui = ["tui",
     "unicode-segmentation",
@@ -49,8 +49,8 @@ render-tui = ["tui",
     "futures-lite",
     "futures-core",
     "async-io",
-    "humantime"]
-render-line = ["crosstermion/color", "humantime", "unicode-width"]
+    "jiff"]
+render-line = ["crosstermion/color", "jiff", "unicode-width"]
 render-line-crossterm = ["crosstermion/crossterm"]
 render-line-autoconfigure = ["is-terminal"]
 
@@ -69,7 +69,6 @@ tui = { package = "ratatui", version = "0.26.0", optional = true, default-featur
 tui-react = { version = "0.23.0", optional = true }
 futures-core = { version = "0.3.4", optional = true, default-features = false }
 futures-lite = { version = "2.1.0", optional = true }
-humantime = { version = "2.1.0", optional = true }
 unicode-segmentation = { version = "1.6.0", optional = true }
 unicode-width = { version = "0.1.7", optional = true }
 crosstermion = { version = "0.14.0", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This crate comes with various cargo features to tailor it to your needs.
 * **unit-human**
   * Display counts in a way that is easier to grasp for humans, using the tiny `human_format` crate.
 * **unit-duration**
-  * Displays time in seconds like '_5m4s_' using the tiny `humantime` crate.
+  * Displays time in seconds like '_5m4s_' using the `jiff` crate's friendly duration format.
 
 ## Features
 

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -4,10 +4,8 @@
 compile_error!(
     "The `render-tui` feature must be set, along with either `render-tui-crossterm` or `render-tui-termion`"
 );
-#[cfg(not(any(feature = "render-tui-crossterm", feature = "render-tui-termion")))]
-compile_error!(
-    "Please set either the 'render-tui-crossterm' or 'render-tui-termion' feature whne using the 'render-tui'"
-);
+#[cfg(not(any(feature = "render-tui-crossterm")))]
+compile_error!("Please set the 'render-tui-crossterm' feature when using the 'render-tui'");
 
 fn main() -> Result {
     env_logger::init();

--- a/examples/shared/args.rs
+++ b/examples/shared/args.rs
@@ -63,17 +63,9 @@ pub struct Options {
     #[argh(option)]
     pub line_end: Option<prodash::progress::key::Level>,
 
-    /// if set (default: false), we will stop running the TUI once there the list of drawable progress items is empty.
-    #[argh(switch)]
-    pub stop_if_empty_progress: bool,
-
     /// set the renderer to use, defaults to "tui", and furthermore allows "line" and "log".
     ///
     /// If set ot "log", there will only be logging. Set 'RUST_LOG=info' before running the program to see them.
     #[argh(option, short = 'R')]
     pub renderer: Option<String>,
-
-    /// has not effect - use the NO_COLOR environment variable instead.
-    #[argh(switch)]
-    pub no_line_color: bool,
 }

--- a/examples/units.rs
+++ b/examples/units.rs
@@ -1,13 +1,9 @@
 #![deny(unsafe_code)]
 
 #[cfg(not(feature = "render-tui"))]
-compile_error!(
-    "The `render-tui` feature must be set, along with either `render-tui-crossterm` or `render-tui-termion`"
-);
-#[cfg(not(any(feature = "render-tui-crossterm", feature = "render-tui-termion")))]
-compile_error!(
-    "Please set either the 'render-tui-crossterm' or 'render-tui-termion' feature whne using the 'render-tui'"
-);
+compile_error!("The `render-tui` feature must be set, along with the `render-tui-crossterm`");
+#[cfg(not(any(feature = "render-tui-crossterm")))]
+compile_error!("Please set the 'render-tui-crossterm' feature when using the 'render-tui'");
 
 use std::{error::Error, sync::Arc};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(unsafe_code, missing_docs)]
+#![allow(clippy::empty_docs)]
 
 /*!
 Prodash is a dashboard for displaying the progress of concurrent application.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use log::info;
 #[cfg(feature = "progress-tree-log")]
 pub use log::warn;
 
-#[cfg(any(feature = "humantime", feature = "local-time"))]
+#[cfg(any(feature = "jiff", feature = "local-time"))]
 ///
 pub mod time;
 

--- a/src/render/line/draw.rs
+++ b/src/render/line/draw.rs
@@ -149,7 +149,7 @@ pub fn all(out: &mut impl io::Write, show_progress: bool, state: &mut State, con
         let level_range = config
             .level_filter
             .clone()
-            .unwrap_or(RangeInclusive::new(0, progress::key::Level::max_value()));
+            .unwrap_or(RangeInclusive::new(0, progress::key::Level::MAX));
         let lines_to_be_drawn = state
             .tree
             .iter()
@@ -253,7 +253,7 @@ fn draw_progress_bar(p: &Value, style: Style, mut blocks_available: u16, colored
             const CHARS: [char; 6] = ['=', '=', '=', ' ', ' ', ' '];
             buf.push(
                 styled_brush.paint(
-                    (p.step.load(Ordering::SeqCst)..std::usize::MAX)
+                    (p.step.load(Ordering::SeqCst)..usize::MAX)
                         .take(blocks_available as usize)
                         .map(|idx| CHARS[idx % CHARS.len()])
                         .rev()

--- a/src/render/line/mod.rs
+++ b/src/render/line/mod.rs
@@ -1,8 +1,5 @@
-#[cfg(all(
-    feature = "render-line",
-    not(any(feature = "render-line-crossterm", feature = "render-line-termion"))
-))]
-compile_error!("Please choose either one of these features: 'render-line-crossterm' or 'render-line-termion'");
+#[cfg(all(feature = "render-line", not(any(feature = "render-line-crossterm"))))]
+compile_error!("Please use the 'render-line-crossterm' feature");
 
 mod draw;
 mod engine;

--- a/src/render/tui/draw/progress.rs
+++ b/src/render/tui/draw/progress.rs
@@ -140,7 +140,7 @@ pub(crate) fn headline(
 
 struct ProgressFormat<'a>(&'a Option<Value>, u16, Option<unit::display::Throughput>);
 
-impl<'a> fmt::Display for ProgressFormat<'a> {
+impl fmt::Display for ProgressFormat<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             Some(p) => match p.unit.as_ref() {

--- a/src/render/tui/draw/progress.rs
+++ b/src/render/tui/draw/progress.rs
@@ -1,10 +1,5 @@
-use std::{
-    fmt,
-    sync::atomic::Ordering,
-    time::{Duration, SystemTime},
-};
+use std::{fmt, sync::atomic::Ordering, time::Duration};
 
-use humantime::format_duration;
 use tui::{
     buffer::Buffer,
     layout::Rect,
@@ -300,13 +295,14 @@ fn add_block_eta(state: progress::State, progress_text: &mut String) {
             progress_text.push_str(reason);
             progress_text.push(']');
             if let Some(eta) = maybe_eta {
-                let now = SystemTime::now();
+                let eta = jiff::Timestamp::try_from(eta).expect("reasonable system time");
+                let now = jiff::Timestamp::now();
                 if eta > now {
                     use std::fmt::Write;
                     write!(
                         progress_text,
-                        " → {} to {}",
-                        format_duration(eta.duration_since(now).expect("computation to work")),
+                        " → {:#} to {}",
+                        eta.duration_since(now),
                         if let progress::State::Blocked(_, _) = state {
                             "unblock"
                         } else {

--- a/src/render/tui/engine.rs
+++ b/src/render/tui/engine.rs
@@ -89,10 +89,8 @@ pub(crate) enum InterruptDrawInfo {
     Deferred(bool),
 }
 
-#[cfg(not(any(feature = "render-tui-crossterm", feature = "render-tui-termion")))]
-compile_error!(
-    "Please set either the 'render-tui-crossterm' or 'render-tui-termion' feature whne using the 'render-tui'"
-);
+#[cfg(not(any(feature = "render-tui-crossterm")))]
+compile_error!("Please set the 'render-tui-crossterm' feature when using the 'render-tui'");
 
 use crosstermion::crossterm::event::{KeyCode, KeyEventKind, KeyModifiers};
 use crosstermion::{

--- a/src/time.rs
+++ b/src/time.rs
@@ -36,23 +36,15 @@ mod utc {
     ///
     /// Available without the `localtime` feature toggle.
     pub fn format_time_for_messages(time: SystemTime) -> String {
-        String::from_utf8_lossy(
-            &humantime::format_rfc3339_seconds(time).to_string().as_bytes()
-                [DATE_TIME_YMD..DATE_TIME_YMD + DATE_TIME_HMS],
-        )
-        .into_owned()
+        let time = jiff::Timestamp::try_from(time).expect("reasonable system time");
+        time.strftime("%T").to_string()
     }
 
     /// Return a string representing the current time as UTC.
     ///
     /// Available without the `localtime` feature toggle.
     pub fn format_now_datetime_seconds() -> String {
-        String::from_utf8_lossy(
-            &humantime::format_rfc3339_seconds(std::time::SystemTime::now())
-                .to_string()
-                .as_bytes()[.."2020-02-13T00:51:45".len()],
-        )
-        .into_owned()
+        jiff::Timestamp::now().strftime("%FT%T").to_string()
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -30,7 +30,6 @@ mod utc {
     use std::time::SystemTime;
 
     use super::DATE_TIME_HMS;
-    const DATE_TIME_YMD: usize = "2020-02-13T".len();
 
     /// Return a string representing the current date and time as UTC.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -243,7 +243,7 @@ mod impls {
 
     pub trait Sealed {}
 
-    impl<'a, T> Count for &'a T
+    impl<T> Count for &T
     where
         T: Count + ?Sized,
     {
@@ -268,7 +268,7 @@ mod impls {
         }
     }
 
-    impl<'a, T> Count for &'a mut T
+    impl<T> Count for &mut T
     where
         T: Count + ?Sized,
     {
@@ -293,7 +293,7 @@ mod impls {
         }
     }
 
-    impl<'a, T> Progress for &'a mut T
+    impl<T> Progress for &mut T
     where
         T: Progress + ?Sized,
     {
@@ -350,7 +350,7 @@ mod impls {
         }
     }
 
-    impl<'a, T> NestedProgress for &'a mut T
+    impl<T> NestedProgress for &mut T
     where
         T: NestedProgress + ?Sized,
     {

--- a/src/unit/display.rs
+++ b/src/unit/display.rs
@@ -117,7 +117,7 @@ impl What {
     }
 }
 
-impl<'a> UnitDisplay<'a> {
+impl UnitDisplay<'_> {
     /// Display everything, values and the unit.
     pub fn all(&mut self) -> &Self {
         self.display = What::ValuesAndUnit;
@@ -135,7 +135,7 @@ impl<'a> UnitDisplay<'a> {
     }
 }
 
-impl<'a> fmt::Display for UnitDisplay<'a> {
+impl fmt::Display for UnitDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let unit: &dyn DisplayValue = self.parent.as_display_value();
         let mode = self.parent.mode;

--- a/src/unit/duration.rs
+++ b/src/unit/duration.rs
@@ -1,6 +1,4 @@
-use std::{fmt, time};
-
-use humantime::format_duration;
+use std::fmt;
 
 use crate::{progress::Step, unit::DisplayValue};
 
@@ -10,13 +8,15 @@ pub struct Duration;
 
 impl DisplayValue for Duration {
     fn display_current_value(&self, w: &mut dyn fmt::Write, value: Step, _upper: Option<Step>) -> fmt::Result {
-        w.write_str(&format_duration(time::Duration::new(value as u64, 0)).to_string())
+        let dur = jiff::SignedDuration::from_secs(value as i64);
+        w.write_str(&format!("{dur:#}"))
     }
     fn separator(&self, w: &mut dyn fmt::Write, _value: Step, _upper: Option<Step>) -> fmt::Result {
         w.write_str(" of ")
     }
     fn display_upper_bound(&self, w: &mut dyn fmt::Write, upper_bound: Step, _value: Step) -> fmt::Result {
-        w.write_str(&format_duration(time::Duration::new(upper_bound as u64, 0)).to_string())
+        let dur = jiff::SignedDuration::from_secs(upper_bound as i64);
+        w.write_str(&format!("{dur:#}"))
     }
 
     fn dyn_hash(&self, state: &mut dyn std::hash::Hasher) {


### PR DESCRIPTION
This PR bumps to `jiff 0.2` and removes `humantime` in favor of `jiff`.

Back when I first contributed the change to move to Jiff
in #31, Jiff didn't have a way of formatting durations
like `humantime` does. But Jiff does [support that
now](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html).

One part I'm a little unsure about here is that prodash was still
trying to emit times even when `local-time` wasn't enabled, and it
was using `humantime` to do this. But now that Jiff is used for both
things, it probably doesn't make sense to have this fallback. (I think
it's also somewhat suspicious, since printing UTC time as if it were
local time is likely confusing.) In any case, I left it as it was,
except with using Jiff.

I tried running tests locally, but one of the tui rendering tests just
hung indefinitely for me.
