### PR TITLE
Bump `bytesize` from major version 1 to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ signal-hook = { version = "0.3.9", optional = true, default-features = false }
 is-terminal = { version = "0.4.9", optional = true }
 
 # units
-bytesize = { version = "1.0.1", optional = true }
+bytesize = { version = "2.0.1", optional = true }
 human_format = { version = "1.0.3", optional = true }
 
 [package.metadata.docs.rs]

--- a/src/unit/bytes.rs
+++ b/src/unit/bytes.rs
@@ -8,7 +8,7 @@ pub struct Bytes;
 
 impl Bytes {
     fn format_bytes(w: &mut dyn fmt::Write, value: Step) -> fmt::Result {
-        let string = bytesize::to_string(value as u64, false);
+        let string = bytesize::ByteSize(value as u64).display().si().to_string();
         for token in string.split(' ') {
             w.write_str(token)?;
         }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -60,12 +60,12 @@ mod dynamic {
                         None
                     )
                 ),
-                "1.0KB/10.0GB [0%]"
+                "1.0kB/10.0GB [0%]"
             );
         }
         #[test]
         fn just_value() {
-            assert_eq!(format!("{}", unit::dynamic(Bytes).display(5540, None, None)), "5.5KB");
+            assert_eq!(format!("{}", unit::dynamic(Bytes).display(5540, None, None)), "5.5kB");
         }
     }
 }


### PR DESCRIPTION
This upgrades the `bytesize` dependency in `Cargo.toml` from version 1.0.1 (which was usually selecting 1.3.3) to 2.0.1 (which is the latest version).

There were some nontrivial API changes from major version 1 to 2. Accordingly, this adapts `Bytes::format_bytes()` to the API change.

The old `bytesize::to_string()` function was confusing in its second parameter `si_prefix: bool`, which is why it was removed. But it looks like a value of `false`, as we were passing, actually caused decimal SI units (rather than binary IEC units) to be used. It's not obvious which units `prodash` intended to use `bytesize` to convert to and display in. But this seems to be a minimal change to adapt to the new major version.

In spite of the name `si_prefix` for the old parameter, experiments show that setting it to `true` caused values to be converted to and presented in binary IEC units.

Although this attempts not to change which actual units are used, it does produce observable differences for some of them, in how they are presented. In particular, a decimal SI kilobyte is least ambiguously abbreviated "kB" (because "k" is an SI unit symbol prefix for "kilo" in its meaning of 1000), but it was previously written as "KB". It is now expected to be writen as "kB". Tests catch this distinction, and are updated here accordingly to assert that the generally preferable "kB" symbol for decimal SI kilobyte is used.

See also: https://github.com/GitoxideLabs/gitoxide/issues/1947#issuecomment-2795974907

---

A few ways this might not be ready:

- As noted, I'm not sure what the actual intended behavior is here in terms of whether the units should be the decimal SI units or binary IEC units. My preference for units that are based in counts of bytes is, in most applications, to use binary IEC units--but that does not mean it's what people expect here, and it's a bigger change from what was done before so I did not change to that here, instead using the decimal SI units.
- There's a behavioral change here, which required a change to the tests--writing "kB" instead of "KB"--so it seems like maybe this should be a conventional commit, but I haven't made it one, not being sure what is expected here.
- It might be good to try this out in a real-world application, such as by building `gitoxide` against `prodash` with these changes and observing what `gix clone` on a medium-to-large repository looks like.