### PR TITLE
Make CI easier to read and run, and update it with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: '/'
+  schedule:
+    interval: weekly
+  groups:
+    github-actions:
+      patterns: ['*']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
+    - "run-ci/**"
+    - "**/run-ci/**"
   pull_request:
-    branches: [ main ]
+    branches:
+    - main
 
 jobs:
   build-and-test-linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,19 @@ jobs:
   build-and-test-on-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: stable
-          override: true
-      - name: "Check (crossterm)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features=render-tui,render-tui-crossterm,render-line,render-line-crossterm,signal-hook,render-line-autoconfigure,progress-tree --all --bins --tests --examples
-      - name: "Test (crossterm)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features=render-tui,render-tui-crossterm,render-line,render-line-crossterm,signal-hook,render-line-autoconfigure,progress-tree progress-tree" --all
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: default
+        toolchain: stable
+        override: true
+    - name: "Check (crossterm)"
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --features=render-tui,render-tui-crossterm,render-line,render-line-crossterm,signal-hook,render-line-autoconfigure,progress-tree --all --bins --tests --examples
+    - name: "Test (crossterm)"
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --features=render-tui,render-tui-crossterm,render-line,render-line-crossterm,signal-hook,render-line-autoconfigure,progress-tree progress-tree" --all


### PR DESCRIPTION
This is analogous to https://github.com/Byron/cargo-smart-release/pull/43, but here in `prodash`. The main differences are that the changes here are simpler and the Dependabot configuration is set to a weekly cadence rather than a monthly cadence--I used montly in csr because it is less active. (There are fewer jobs here using fewer actions but the actions in use are even more outdated.)