### PR TITLE
Set explicit `contents: read` permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This specifies `contents: read` permissions only for `cy.yml`, since no other permissions are currently needed in it. In so doing, [it avoids](https://github.com/github/codeql/blob/main/actions/ql/src/Security/CWE-275/MissingActionsPermissions.md) the ambiguous and sometimes greater than intended workflow permissions assigned if no `permissions` key is used.

This is similar in motivation to, though much simpler than, https://github.com/GitoxideLabs/gitoxide/pull/1668/commits/f41a58cb0c0a1417fa08d69b2db172fc6f2d995c (https://github.com/GitoxideLabs/gitoxide/pull/1668).

---

Although I worked on the workflow in #34, I did not notice that this was missing at that time. But I enabled experimental CodeQL queries for GitHub Actions workflows in my fork, which conveniently found this.

Although CodeQL can be enabled by writing a workflow that runs it (an "advanced" setup), I suggest enabling the [default setup](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning), which requires no workflow file, in this repository's [security settings](https://github.com/EliahKagan/prodash/settings/security_analysis). CodeQL doesn't support Rust, so this would only be for GitHub Actions, for which I think it should not be necessary to go beyond the default setup. (You may also want to enable it in [`cargo-smart-release`](https://github.com/Byron/cargo-smart-release).)

By the way, I've found that, at least as things stand now, for GitHub Actions queries, the default setup is in practice *more* versatile than advanced setups in one important way. Like advanced setups, the default allows configuring which [suite of queries](https://docs.github.com/en/code-security/code-scanning/managing-your-code-scanning-configuration/codeql-query-suites) to run. Since, unlike advanced setups, the default setup requires no workflow file, this makes it easy for an upstream repository and its forks to run different suites, without diverging. For example, I enabled the default setup with the `default` suite in gitoxide [about 10 days ago](https://github.com/GitoxideLabs/gitoxide/actions/runs/14301298438), while also running the default setup with the `security-extended` suite in my fork, which includes queries that are for less serious problems or that may carry more false positives.